### PR TITLE
Fixes Issue #3

### DIFF
--- a/syntax/mma.vim
+++ b/syntax/mma.vim
@@ -1296,7 +1296,7 @@ syntax match mmaOperator "&"
 syntax match mmaOperator "?\{1,2}"
 
 "User Symbols
-syntax match mmaSymbol "[^0-9][A-Za-z0-9`$]\+\s*\%([@[]\|/:\|/\=/@\)\@=" contains=mmaOperator,mmaSystemSymbol,mmaBrackets,mmaError
+syntax match mmaSymbol "[^0-9"][A-Za-z0-9`$]\+\s*\%([@[]\|/:\|/\=/@\)\@=" contains=mmaOperator,mmaSystemSymbol,mmaBrackets,mmaError
 syntax match mmaSymbol "\<[^0-9][A-Za-z0-9`$]\+\>" contains=mmaOperator,mmaSystemSymbol,mmaBrackets,mmaError
 syntax match mmaSymbol "\~\s*[^~]\+\s*\~"ms=s+1,me=e-1 contains=mmaOperator,mmaSystemSymbol,mmaBrackets,mmaError
 syntax match mmaSymbol "//\s*[A-Za-z0-9`$]\+"ms=s+2 contains=mmaOperator,mmaSystemSymbol,mmaBrackets,mmaError


### PR DESCRIPTION
* Fixed mmaSymbol appearing at start of mmaString, see #3 

Added `"` to no-match at start of mmaSymbol.